### PR TITLE
fix string utf8 encoding in ReportValue.php

### DIFF
--- a/lib/PhpReports/ReportValue.php
+++ b/lib/PhpReports/ReportValue.php
@@ -69,7 +69,8 @@ class ReportValue {
 			else return $value;
 		}
 		elseif($type === 'string') {
-			return utf8_encode($value);
+			if(mb_check_encoding($value, 'UTF-8')) return $value;
+			else return utf8_encode($value);
 		}
 	}
 	


### PR DESCRIPTION
I'm actually making PR out of issue discussion at https://github.com/jdorn/php-reports/issues/100. The point is that value should not be encoded to utf8 every time; it should only be encoded if it wasn't utf8 already.
