### PR TITLE
Allow a non-multiple input textarea

### DIFF
--- a/lib/PhpReports/Report.php
+++ b/lib/PhpReports/Report.php
@@ -348,6 +348,8 @@ class Report {
 						}
 					}
 				}
+				elseif ($params['type'] === 'textarea'){
+					$params['is_textarea'] = true;
 				else {
 					if($params['multiple']) {
 						$params['is_textarea'] = true;


### PR DESCRIPTION
Currently textareas show up as just text inputs unless they are also multiple inputs. This allows simple textareas to render correctly.